### PR TITLE
[bug] Fix browser zoom in/out bug causing sliders to reappear

### DIFF
--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -151,7 +151,7 @@ export default class Scrollbars extends Component {
         const { scrollWidth, clientWidth } = this.view;
         const trackWidth = getInnerWidth(this.trackHorizontal);
         const width = Math.ceil(clientWidth / scrollWidth * trackWidth);
-        if (trackWidth === width) return 0;
+        if (trackWidth <= width) return 0;
         if (thumbSize) return thumbSize;
         return Math.max(width, thumbMinSize);
     }
@@ -161,7 +161,7 @@ export default class Scrollbars extends Component {
         const { scrollHeight, clientHeight } = this.view;
         const trackHeight = getInnerHeight(this.trackVertical);
         const height = Math.ceil(clientHeight / scrollHeight * trackHeight);
-        if (trackHeight === height) return 0;
+        if (trackHeight <= height) return 0;
         if (thumbSize) return thumbSize;
         return Math.max(height, thumbMinSize);
     }


### PR DESCRIPTION
There is a bug in the original repo causing sliders to appear randomly when using browser zoom. The original description is here: https://github.com/malte-wessel/react-custom-scrollbars/issues/320

I implemented and tested the fix.

Here's the bug (look at the right slider appearing when zooming out):
![Screen+Recording+2021-04-30+at+01 55 57+PM](https://user-images.githubusercontent.com/54366429/116741674-08b5a580-a9bc-11eb-8210-3799db63600c.gif)
