### PR TITLE
Fix meta viewport suggestion

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,7 +23,7 @@ Also don't forget to set the `viewport` meta tag, if you want to **support mobil
 ```html
 <meta
   name="viewport"
-  content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>
+  content="width=device-width, initial-scale=1.0"/>
 ```
 
 ## Events


### PR DESCRIPTION
This suggestion was harmful. It has nothing to do with the functionality of the library, the library works just fine if the user retains the ability to zoom in and out on the page.

https://www.a11yproject.com/posts/never-use-maximum-scale/

People who know this stuff won't make the mistake, but people who don't will just blindly copy-paste. 