### PR TITLE
fix: double slashes in repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com//RobPethick/react-custom-scrollbars-2.git"
+    "url": "https://github.com/RobPethick/react-custom-scrollbars-2.git"
   },
   "keywords": [
     "scroll",
@@ -30,9 +30,9 @@
   "author": "Rob Pethick",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com//RobPethick/react-custom-scrollbars-2/issues"
+    "url": "https://github.com/RobPethick/react-custom-scrollbars-2/issues"
   },
-  "homepage": "https://github.com//RobPethick/react-custom-scrollbars-2",
+  "homepage": "https://github.com/RobPethick/react-custom-scrollbars-2",
   "devDependencies": {
     "babel-cli": "^6.2.0",
     "babel-core": "^6.2.1",


### PR DESCRIPTION
The same links appear on npm, they're not correct right now.