### PR TITLE
Fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export interface positionValues {
     scrollTop: number;
 }
 
-export interface ScrollbarProps extends React.HTMLProps<Scrollbars> {
+export interface ScrollbarProps extends React.HTMLProps<Scrollbars['container']> {
     onScroll?: React.UIEventHandler<any>;
     onScrollFrame?: (values: positionValues) => void;
     onScrollStart?: () => void;


### PR DESCRIPTION
`Scrollbars` is a component type actually, and doesn't inherit `Element`. I think it's meant to be every possible prop types for a container itself, which is an `HTMLDivElement`,

since all props [src/Scrollbars/index.js#L512](https://github.com/RobPethick/react-custom-scrollbars-2/blob/master/src/Scrollbars/index.js#L512)
except explicit component ones [src/Scrollbars/index.js#L489-L510](https://github.com/RobPethick/react-custom-scrollbars-2/blob/master/src/Scrollbars/index.js#L489-L510)
passed to the container itself [src/Scrollbars/index.js#L573](https://github.com/RobPethick/react-custom-scrollbars-2/blob/master/src/Scrollbars/index.js#L573)